### PR TITLE
Fix project file

### DIFF
--- a/Test iOS project.xcodeproj/project.pbxproj
+++ b/Test iOS project.xcodeproj/project.pbxproj
@@ -239,7 +239,6 @@
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
 				ENABLE_TESTABILITY = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -261,6 +260,7 @@
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OBJC_BRIDGING_HEADER = "Test iOS project/Test_iOS_project_Bridging_Header.h";
 				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 			};
 			name = Debug;
@@ -302,7 +302,6 @@
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_NS_ASSERTIONS = NO;
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
-				ENABLE_USER_SCRIPT_SANDBOXING = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu17;
 				GCC_NO_COMMON_BLOCKS = YES;
 				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
@@ -317,6 +316,7 @@
 				MTL_FAST_MATH = YES;
 				SDKROOT = iphoneos;
 				SWIFT_COMPILATION_MODE = wholemodule;
+				SWIFT_OBJC_BRIDGING_HEADER = "Test iOS project/Test_iOS_project_Bridging_Header.h";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;


### PR DESCRIPTION
- You missed the `Additionally, make sure to disable the Sandbox Scripting capability.` step in the setup instructions.
-  Lynx appears to be written in Objective-C. Your app is written in Swift.
	- In order to interpolate them you need to implement a bridging header within your project.
	- You were half way there as you have created "Test_iOS_project-Bridging_Header.h". However, you have not configured the project file to actually use the bridging header.